### PR TITLE
Feat: authentication keycloak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_KEYCLOAK_URL="http://localhost:8080"
+VITE_KEYCLOAK_AD_REALM="admin"
+VITE_KEYCLOAK_AD_CLIENT_ID="admin-cli"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "keycloak-js": "^25.0.2",
+    "pinia": "^2.2.0",
     "sass": "^1.77.4",
     "vue": "^3.4.21",
     "vue-router": "4",

--- a/src/infra/auth/auth-ad.ts
+++ b/src/infra/auth/auth-ad.ts
@@ -1,0 +1,7 @@
+export const AUTH_AD = Symbol('AUTH_AD');
+export interface AuthAd {
+  connect(): Promise<boolean>;
+  refreshToken(): Promise<string>;
+  disconnect(): Promise<void>;
+  isAuthenticated(): boolean;
+}

--- a/src/infra/auth/keycloak-ad.service.ts
+++ b/src/infra/auth/keycloak-ad.service.ts
@@ -1,0 +1,77 @@
+import Keycloak, { KeycloakConfig } from 'keycloak-js';
+import { AuthStore } from '../../store/auth-store.interface';
+import { AuthAd } from './auth-ad';
+
+export class KeycloakAdService implements AuthAd {
+  private keycloakInstance: Keycloak;
+
+  constructor(private readonly storeService: AuthStore) {
+    this.keycloakInstance = new Keycloak(this.createConfig());
+  }
+
+  async connect(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      this.keycloakInstance
+        .init({
+          onLoad: 'check-sso',
+        })
+        .then(async (authenticated) => {
+          if (!authenticated) {
+            this.keycloakInstance.login();
+          } else {
+            const clientId =
+              this.keycloakInstance.tokenParsed?.resource_access![
+                import.meta.env.VITE_KEYCLOAK_AD_CLIENT_ID
+              ];
+
+            if (clientId) {
+              const userRoles = clientId.roles;
+              const userProfile = await this.keycloakInstance.loadUserProfile();
+
+              await this.insertStore(
+                this.keycloakInstance.token!,
+                userProfile,
+                userRoles
+              );
+            }
+          }
+          resolve(authenticated);
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    this.keycloakInstance.logout();
+  }
+
+  async refreshToken(): Promise<string> {
+    this.keycloakInstance.login();
+    await this.keycloakInstance.updateToken();
+    return this.keycloakInstance.token!;
+  }
+
+  public isAuthenticated(): boolean {
+    return !!this.keycloakInstance.authenticated;
+  }
+
+  private insertStore(token: string, account: any, roles: string[]) {
+    return new Promise<void>((resolve) => {
+      this.storeService.setToken(token);
+      this.storeService.setUsername(`${account.firstName} ${account.lastName}`);
+      this.storeService.setUserCode(account.username.split('@')[0]);
+      this.storeService.setUserRoles(roles);
+      resolve();
+    });
+  }
+
+  createConfig(): KeycloakConfig {
+    return {
+      url: import.meta.env.VITE_KEYCLOAK_URL,
+      realm: import.meta.env.VITE_KEYCLOAK_AD_REALM,
+      clientId: import.meta.env.VITE_KEYCLOAK_AD_CLIENT_ID,
+    };
+  }
+}

--- a/src/infra/dependecy-injection/dependency-injection.ts
+++ b/src/infra/dependecy-injection/dependency-injection.ts
@@ -1,0 +1,21 @@
+import { App } from 'vue';
+
+import { authStore } from '../../store/auth-store';
+import { AuthStore } from '../../store/auth-store.interface';
+import { AUTH_AD, AuthAd } from '../auth/auth-ad';
+import { KeycloakAdService } from '../auth/keycloak-ad.service';
+
+export class DependencyInjection {
+  store: AuthStore;
+  authService: AuthAd;
+
+  constructor() {
+    this.store = authStore();
+    this.authService = new KeycloakAdService(this.store);
+  }
+
+  async execute(applicationVue: App<Element>) {
+    // TODO: Add more service here
+    applicationVue.provide(AUTH_AD, this.authService);
+  }
+}

--- a/src/infra/plugins/pinia.ts
+++ b/src/infra/plugins/pinia.ts
@@ -1,0 +1,5 @@
+import { createPinia } from 'pinia';
+
+const pinia = createPinia();
+
+export default pinia;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
 import { createApp } from 'vue';
 
-import router from './routes/router';
 import vuetify from './plugins/vuetify';
 
 import App from './App.vue';
+import { DependencyInjection } from './infra/dependecy-injection/dependency-injection';
+import pinia from './infra/plugins/pinia';
+import router from './routes/router';
 
-createApp(App).use(vuetify).use(router).mount('#app');
+const app = createApp(App).use(vuetify).use(pinia);
+const dependencyInjectionManager = new DependencyInjection();
+
+dependencyInjectionManager.authService.connect().then(() => {
+  app.use(router);
+  dependencyInjectionManager.execute(app);
+
+  app.mount('#app');
+});

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,13 +1,13 @@
-import { createMemoryHistory, createRouter } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 
 import HomeView from '../modules/home/home.component.vue';
 import RouterModule from '../modules/league/route';
 
 const routes = [{ path: '/', component: HomeView }, ...RouterModule];
 
-const router = createRouter({
-  history: createMemoryHistory(),
-  routes,
+export const router = createRouter({
+  history: createWebHistory(),
+  routes: [...routes],
 });
 
 export default router;

--- a/src/store/auth-store.interface.ts
+++ b/src/store/auth-store.interface.ts
@@ -1,0 +1,9 @@
+export interface AuthStore {
+  username: string;
+  token: string;
+  userRoles: any[];
+  setToken(token: string): void;
+  setUsername(username: string): void;
+  setUserCode(code: string): void;
+  setUserRoles(roles: string[]): void;
+}

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+
+export const authStore = defineStore('auth', {
+  state: () => ({
+    userToken: '',
+    username: '',
+    usercode: '',
+    userRoles: new Array<string>(),
+  }),
+  getters: {
+    token(): string {
+      return this.userToken;
+    },
+  },
+  actions: {
+    setToken(token: string) {
+      this.userToken = token;
+    },
+    setUsername(username: string) {
+      this.username = username;
+    },
+    setUserCode(usercode: string) {
+      this.usercode = usercode;
+    },
+    setUserRoles(roles: []) {
+      this.userRoles = roles;
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,11 @@
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.2.tgz#a5a17377ca810c7f0153232ff1dcfa25bd5694be"
   integrity sha512-134clD8u7cBBXdmBbXI282gHGF7T/eAbD/G7mAK2llQF62IbI4ny28IVamZVMoJSvfImC2Xxnj732hXkJvUj6g==
 
+"@vue/devtools-api@^6.6.3":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.3.tgz#b23a588154cba8986bba82b6e1d0248bde3fd1a0"
+  integrity sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==
+
 "@vue/language-core@2.0.19":
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-2.0.19.tgz#d55f9c1e92690c77ffd599688ba36c2b50c4303b"
@@ -490,6 +495,24 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+js-sha256@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
+  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
+
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
+keycloak-js@^25.0.2:
+  version "25.0.2"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-25.0.2.tgz#10de8352ae7bb0d46396e4f083b40b959285791b"
+  integrity sha512-ACLf5O5PqzfDJwGqvLpqM0kflYWmyl3+T7M2C23gztJYccDxdfNP54+B9OkXz2GnDpLUId0ceoA+lbHw9t4Wng==
+  dependencies:
+    js-sha256 "^0.11.0"
+    jwt-decode "^4.0.0"
+
 magic-string@^0.30.10:
   version "0.30.10"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.10.tgz#123d9c41a0cb5640c892b041d4cfb3bd0aa4b39e"
@@ -533,6 +556,14 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pinia@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.2.0.tgz#cd006f7c1365ae326b9f95f622b7ad1078c398a4"
+  integrity sha512-iPrIh26GMqfpUlMOGyxuDowGmYousTecbTHFwT0xZ1zJvh23oQ+Cj99ZoPQA1TnUPhU6AuRPv6/drkTCJ0VHQA==
+  dependencies:
+    "@vue/devtools-api" "^6.6.3"
+    vue-demi "^0.14.8"
 
 postcss@^8.4.38:
   version "8.4.38"
@@ -616,6 +647,11 @@ vite@^5.2.0:
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vue-demi@^0.14.8:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
+  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
 
 vue-router@4:
   version "4.3.2"


### PR DESCRIPTION

## Visão geral

Esse PR implementa a configuração da autenticação no front-end utilizando o keycloak;

## Implementações

-  Foi adicionado a estrutura de pastas `infra`;
-  Adicionado a configuração do keycloak em  `src/infra/auth/keycloak-ad.service.ts`;
-  Configurado o plugin pinia em `src/infra/plugins/pinia.ts`;
-  Configuração da store de auth em `src/store/auth-store.ts`;
-  Adicionado envs referentes ao keycloak;


## Resultado obtido (prints, vídeos ou GIFs)

# Tela de login do keycloak
![image](https://github.com/user-attachments/assets/832a6893-a85f-4868-8dc5-babb0431419f)


## Critérios de teste

- [ ] Deve ser possivel realizar o login apartir do keycloak antes de acessar as rotas da aplicação;
- [ ] Ao realizar o login deve redirecionar para a pagina home;


## Passos para testar
1. Rodar o container do keycloak localmente
2. Adicionar as seguintes variaveis de ambiente:  VITE_KEYCLOAK_URL, VITE_KEYCLOAK_AD_REALM, VITE_KEYCLOAK_AD_CLIENT_ID (As informações devem coincidir com o que foi criado na realm)
3. Rodar a branch localmente

## Observações relevantes:

Como a lib tenta startar o keycloak antes de utilizar as rotas da aplicação, isso faz com que se não tiver rodando o keycloak ou não ter configurado os .envs corretamente gere um erro na aplicação.
